### PR TITLE
fix(ci): install icon tools on macOS and Windows build runners

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -36,6 +36,15 @@ jobs:
         if: runner.os == 'Linux'
         run: sudo apt-get install -y librsvg2-bin icoutils
 
+      - name: Install icon tools (macOS)
+        if: runner.os == 'macOS'
+        run: brew install imagemagick
+
+      - name: Install icon tools (Windows)
+        if: runner.os == 'Windows'
+        run: choco install imagemagick -y
+        shell: pwsh
+
       - name: Publish (single-file)
         run: >-
           dotnet publish Ready4Balfolk.UI/Ready4Balfolk.UI.csproj


### PR DESCRIPTION
## Summary
- The `generate-icons.sh` script requires SVG-to-PNG and ICO conversion tools
- Only the Linux runner had them installed (`librsvg2-bin` + `icoutils`)
- macOS and Windows builds now install ImageMagick, which the script already supports as an alternative
- This fixes the release workflow failure where macOS publish failed with "Missing required tools for icon generation"

## Test plan
- [ ] Merge this PR
- [ ] Re-run the release workflow with version `1.0.0`
- [ ] Verify all 3 platform builds succeed