### PR TITLE
fix(ci): use correct staging path for Flatpak build

### DIFF
--- a/.github/workflows/build-flatpak.yml
+++ b/.github/workflows/build-flatpak.yml
@@ -31,20 +31,22 @@ jobs:
 
       - name: Stage Flatpak content
         run: |
-          mkdir -p flatpak-stage/stage/bin
-          cp -r flatpak-publish/* flatpak-stage/stage/bin/
-          chmod +x flatpak-stage/stage/bin/Ready4Balfolk.UI
+          STAGE=packaging/linux/flatpak-stage
+
+          mkdir -p $STAGE/stage/bin
+          cp -r flatpak-publish/* $STAGE/stage/bin/
+          chmod +x $STAGE/stage/bin/Ready4Balfolk.UI
 
           # Desktop file
-          mkdir -p flatpak-stage/stage/share/applications
+          mkdir -p $STAGE/stage/share/applications
           cp packaging/linux/io.github.tjvl.Ready4Balfolk.desktop \
-            flatpak-stage/stage/share/applications/
+            $STAGE/stage/share/applications/
 
           # Icons from generated PNGs
           for size in 16 24 32 48 64 128 256 512; do
             icon="icons/icon-${size}.png"
             if [ -f "$icon" ]; then
-              dest="flatpak-stage/stage/share/icons/hicolor/${size}x${size}/apps"
+              dest="$STAGE/stage/share/icons/hicolor/${size}x${size}/apps"
               mkdir -p "$dest"
               cp "$icon" "$dest/io.github.tjvl.Ready4Balfolk.png"
             fi


### PR DESCRIPTION
## Summary
- The Flatpak manifest references `path: flatpak-stage` relative to its own directory (`packaging/linux/`)
- The workflow was staging content in the workspace root instead, causing "File not found" during `flatpak-builder`
- Fixed by staging into `packaging/linux/flatpak-stage/`

## Test plan
- [ ] Merge this PR
- [ ] Re-run the release workflow with version `1.0.0`
- [ ] Verify Flatpak build succeed